### PR TITLE
Upgrade base image and packages to fix CVE-2018-25032

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Upgrade base image to 3.15.3-1
+- Upgrade zlib package to fix CVE-2018-25032; #3
 
 ## [v6.2.6-1] - 2017-06-20
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cloudogu.com/official/base:3.15.0-1
+FROM registry.cloudogu.com/official/base:3.15.3-1
 
 LABEL NAME="official/redis" \
    VERSION="6.2.6-1" \
@@ -11,8 +11,12 @@ ENV SERVICE_TAGS=webapp \
     USER_ID=1000 \
     STARTUP_DIR=/
 
-RUN set -eux -o pipefail \
-    && apk add redis bash
+RUN set -o errexit \
+ && set -o nounset \
+ && set -o pipefail \
+ && apk update \
+ && apk upgrade \
+ && apk add redis bash
 
 # copy resources files
 COPY resources/ /


### PR DESCRIPTION
### Changed
- Upgrade base image to 3.15.3-1
- Upgrade zlib package to fix CVE-2018-25032

Resolves #3 