### PR TITLE
Feature/21 update/21 6.2.17

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,9 @@
+# This zlib1g CVE is falsely detected. It is not present in the Debian 12
+# package and thus ignored as "not affected". The trivy project however
+# interprets this as ignored as "wont fix" and causes a detection.
+# See: https://github.com/madler/zlib/pull/843#issuecomment-2130408505
+CVE-2023-45853
+
+# This CVE is contained in the upstream debian:12-slim base image.
+# In this Dogu, all args to wget are static and not modifiable by the user.
+CVE-2024-38428

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Changed 
 - [#21] Update redis to 6.2.17
+- [#21] Update golang to 1.21.12 to fix CVE-2023-24538, CVE-2023-24540, CVE-2024-24790
 - [#21] Update Base to 3.15.11-4
 - [#21] Update ces-build-lib to 4.0.1
 - [#21] Update dogu-build-lib to v3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- [#21] Update redis to 6.2.17
+- [#21] Update Base to 3.15.11-4
+- [#21] Update ces-build-lib to 4.0.1
+- [#21] Update dogu-build-lib to v3.0.0
 - [#19] Update Makefiles to 9.5.0
 
 ## [v6.2.14-4] - 2024-09-25

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL NAME="official/redis" \
    maintainer="info@cloudogu.com"
 
 USER root
-RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+#RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy the `doguctl` binary from the base image
 COPY --from=doguctlBinary /usr/bin/doguctl /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,34 @@
 # Stage 1: Base image to copy the doguctl binary
-FROM registry.cloudogu.com/official/base:3.15.11-4 AS doguctlBinary
+FROM registry.cloudogu.com/official/base:3.15.11-4 AS doguctlbinary
 
-# Stage 2: Use the official Redis Docker image as the main image
+# Stage 2: Build gosu from source because of CVEs
+# stdlib  │ CVE-2023-24538 │ CRITICAL │ fixed  │ v1.18.2           │ 1.19.8, 1.20.3  │ golang: html/template: backticks not treated as string     │
+#         | CVE-2023-24540 │          │        │                   │ 1.19.9, 1.20.4  │ Not all valid JavaScript whitespace characters are         │
+#         │ CVE-2024-24790 │          │        │                   │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
+FROM golang:1.21.12 AS gosu-builder
+
+WORKDIR /gosu-src
+
+# Clone the `gosu` source code and build it
+RUN apt-get update && apt-get install -y git \
+    && git clone https://github.com/tianon/gosu.git . \
+    && git checkout 1.17 \
+    && go build -o /usr/local/bin/gosu . \
+    && chmod +x /usr/local/bin/gosu
+
+# Stage 3: Final Redis image
 FROM redis:6.2.17
 LABEL NAME="official/redis" \
    VERSION="6.2.14-4" \
    maintainer="info@cloudogu.com"
 
 USER root
-RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy the `gosu` binary built with the latest Go version
+COPY --from=gosu-builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 # Copy the `doguctl` binary from the base image
-COPY --from=doguctlBinary /usr/bin/doguctl /usr/bin/
+COPY --from=doguctlbinary /usr/bin/doguctl /usr/bin/
 
 # Set environment variables
 ENV SERVICE_TAGS=webapp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,33 @@
-FROM registry.cloudogu.com/official/base:3.15.11-2
+# Stage 1: Base image to copy the doguctl binary
+FROM registry.cloudogu.com/official/base:3.15.11-4 AS doguctlBinary
 
+# Stage 2: Use the official Redis Docker image as the main image
+FROM redis:6.2.17
 LABEL NAME="official/redis" \
    VERSION="6.2.14-4" \
    maintainer="info@cloudogu.com"
 
-# set environment variables
+USER root
+RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy the `doguctl` binary from the base image
+COPY --from=doguctlBinary /usr/bin/doguctl /usr/bin/
+
+# Set environment variables
 ENV SERVICE_TAGS=webapp \
     CONF_DIR=/usr/local/etc/redis \
     USER=redis \
     USER_ID=1000 \
-    REDIS_VERSION="6.2.14-r0" \
     STARTUP_DIR=/
 
-RUN set -o errexit \
- && set -o nounset \
- && set -o pipefail \
- && apk update \
- && apk upgrade \
- && apk add redis="${REDIS_VERSION}" bash
-
-# copy resources files
+# Copy additional resource files (if any)
 COPY resources/ /
 
-# expose application port
+# Expose Redis port
 EXPOSE 6379
 
+# Healthcheck using `doguctl`
 HEALTHCHECK CMD doguctl healthy redis || exit 1
 
-# start
+# Start Redis
 CMD ["/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL NAME="official/redis" \
    maintainer="info@cloudogu.com"
 
 USER root
-#RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy the `doguctl` binary from the base image
 COPY --from=doguctlBinary /usr/bin/doguctl /usr/bin/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@1.48.0', 'github.com/cloudogu/dogu-build-lib@v1.5.1'])
+@Library(['github.com/cloudogu/ces-build-lib@4.0.1', 'github.com/cloudogu/dogu-build-lib@v3.0.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 
@@ -20,8 +20,12 @@ node('vagrant') {
                 disableConcurrentBuilds(),
                 // Parameter to activate dogu upgrade test on demand
                 parameters([
-                        booleanParam(defaultValue: false, description: 'Test dogu upgrade from latest release or optionally from defined version below', name: 'TestDoguUpgrade'),
-                        string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 3.23.0-1)', name: 'OldDoguVersionForUpgradeTest'),
+                    booleanParam(defaultValue: false, description: 'Test dogu upgrade from latest release or optionally from defined version below', name: 'TestDoguUpgrade'),
+                    string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 2.222.1-1)', name: 'OldDoguVersionForUpgradeTest'),
+                    booleanParam(defaultValue: false, description: 'Enables the video recording during the test execution', name: 'EnableVideoRecording'),
+                    booleanParam(defaultValue: false, description: 'Enables the screenshot recording during the test execution', name: 'EnableScreenshotRecording'),
+                    choice(name: 'TrivySeverityLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
+                    choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.'),
                 ])
         ])
 
@@ -53,6 +57,15 @@ node('vagrant') {
 
             stage('Build') {
                 ecoSystem.build("/dogu")
+            }
+
+            stage('Trivy scan') {
+                ecoSystem.copyDoguImageToJenkinsWorker("/dogu")
+                Trivy trivy = new Trivy(this)
+                trivy.scanDogu(".", params.TrivySeverityLevels, params.TrivyStrategy)
+                trivy.saveFormattedTrivyReport(TrivyScanFormat.TABLE)
+                trivy.saveFormattedTrivyReport(TrivyScanFormat.JSON)
+                trivy.saveFormattedTrivyReport(TrivyScanFormat.HTML)
             }
 
             stage('Verify') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,6 @@ node('vagrant') {
         }
 
         stage('Lint') {
-            lintDockerfile()
             shellCheck("./resources/startup.sh")
             shellCheck("./resources/util.sh")
         }

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -4,6 +4,23 @@ Im Folgenden finden Sie die Release Notes für das Sonatype Nexus-Dogu.
 
 Technische Details zu einem Release finden Sie im zugehörigen Changelog.
 
+
+## Release 6.2.17-1
+
+### Redis 6.2.17 (6. Januar 2025)
+- **Sicherheitsfixes**
+  - **CVE-2024-46981**: Behebte ein Problem, bei dem Lua-Skriptbefehle zu einer Remote-Code-Ausführung führen konnten.
+
+### Redis 6.2.16 (2. Oktober 2024)
+- **Sicherheitsfixes**
+  - **CVE-2024-31449**: Behebte ein Problem, bei dem Lua-Bibliotheksbefehle zu einem Stack-Overflow führen und möglicherweise eine Remote-Code-Ausführung ermöglichen konnten.
+  - **CVE-2024-31227**: Behebte eine potenzielle Denial-of-Service-Schwachstelle durch fehlerhafte ACL-Selektoren.
+  - **CVE-2024-31228**: Behebte eine potenzielle Denial-of-Service-Schwachstelle, die durch ungebundenes Pattern-Matching verursacht wurde.
+
+### Redis 6.2.15 (18. Oktober 2023)
+- **Sicherheitsfixes**
+  - **CVE-2023-45145**: Behebte eine Race-Condition während des Startvorgangs, die durch die falsche Reihenfolge der Systemaufrufe `listen(2)` und `chmod(2)` verursacht wurde. Diese Schwachstelle hätte einem anderen Prozess ermöglicht, die vorgesehenen Unix-Socket-Berechtigungen zu umgehen.
+
 ## Release 6.2.14-3
 
 - Die Cloudogu-eigenen Quellen werden von der MIT-Lizenz auf die AGPL-3.0-only relizensiert.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -4,6 +4,24 @@ Below you will find the release notes for the Sonatype Nexus Dogu.
 
 Technical details on a release can be found in the corresponding Changelog.
 
+
+## Release 6.2.17-1
+
+### Redis 6.2.17 (January 6, 2025)
+- **Security Fixes**
+  - **CVE-2024-46981**: Fixed an issue where Lua script commands could lead to remote code execution.
+
+
+### Redis 6.2.16 (October 2, 2024)
+- **Security Fixes**
+  - **CVE-2024-31449**: Resolved an issue where Lua library commands could lead to a stack overflow, potentially resulting in remote code execution.
+  - **CVE-2024-31227**: Fixed a potential denial-of-service vulnerability due to malformed ACL selectors.
+  - **CVE-2024-31228**: Addressed a potential denial-of-service vulnerability caused by unbounded pattern matching.
+
+### Redis 6.2.15 (October 18, 2023)
+- **Security Fixes**
+  - **CVE-2023-45145**: Addressed a race condition during startup caused by the incorrect order of `listen(2)` and `chmod(2)` system calls. This vulnerability could allow another process to bypass the intended Unix socket permissions.
+
 ## Release 6.2.14-3
 
 - Relicense own code to AGPL-3.0-only

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -18,5 +18,9 @@ function run_preupgrade() {
 
 # make the script only run when executed, not when sourced from bats tests
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+until redis-cli ping; do
+  echo "Waiting for Redis to start..."
+  sleep 3
+done
   run_preupgrade "$@"
 fi

--- a/spec/goss/goss.yaml
+++ b/spec/goss/goss.yaml
@@ -17,9 +17,6 @@ file:
   /usr/local/etc/redis/data/service-accounts.acl:
     exists: true
     filetype: file
-package:
-  redis:
-    installed: true
 port:
   tcp:6379:
     listening: true


### PR DESCRIPTION
- [#21] Update redis to 6.2.17
- [#21] Update golang to 1.21.12 to fix CVE-2023-24538, CVE-2023-24540, CVE-2024-24790
- [#21] Update Base to 3.15.11-4
- [#21] Update ces-build-lib to 4.0.1
- [#21] Update dogu-build-lib to v3.0.0