### PR TITLE
- [#31] Update redis to 6.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed 
+- [#31] Update redis to 6.2.20
+### Security
+- [#31] CVE Fixes:
+* [CVE-2025-49844](https://nvd.nist.gov/vuln/detail/CVE-2025-49844) - A Lua script may lead to remote code execution  
+* [CVE-2025-46817](https://nvd.nist.gov/vuln/detail/CVE-2025-46817) - A Lua script may lead to integer overflow and potential RCE  
+* [CVE-2025-46818](https://www.wiz.io/vulnerability-database/cve/cve-2025-46818) - A Lua script can be executed in the context of another user  
+* [CVE-2025-46819](https://nvd.nist.gov/vuln/detail/CVE-2025-46819) - LUA out-of-bound read  
 
 ## [v6.2.19-1] - 2025-07-08
 ### Changed 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update && apt-get install -y git \
     && chmod +x /usr/local/bin/gosu
 
 # Stage 3: Final Redis image
-FROM redis:6.2.19
+FROM redis:6.2.20
 LABEL NAME="official/redis" \
-   VERSION="6.2.19-1" \
+   VERSION="6.2.20-0" \
    maintainer="info@cloudogu.com"
 
 USER root

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,14 @@ Im Folgenden finden Sie die Release Notes für das Sonatype Nexus-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen Changelog.
 
 ## [Unreleased]
+### Changed 
+- Redis ist nun in der Version v6.2.20 verfügbar [Release-Notes](https://github.com/redis/redis/releases/tag/6.2.20)
+### Sicherheit
+- Behebung folgender CVEs:
+* [CVE-2025-49844](https://nvd.nist.gov/vuln/detail/CVE-2025-49844) - Ein Lua-Skript kann zur Remote-Code-Ausführung führen  
+* [CVE-2025-46817](https://nvd.nist.gov/vuln/detail/CVE-2025-46817) - Ein Lua-Skript kann zu einem Integer Overflow und potenzieller Remote-Code-Ausführung führen  
+* [CVE-2025-46818](https://www.wiz.io/vulnerability-database/cve/cve-2025-46818) - Ein Lua-Skript kann im Kontext eines anderen Benutzers ausgeführt werden  
+* [CVE-2025-46819](https://nvd.nist.gov/vuln/detail/CVE-2025-46819) - Lua Out-of-Bounds-Read  
 
 ## [v6.2.19-1] - 2025-07-08
 ### Changed 

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,8 +5,18 @@ Below you will find the release notes for the Sonatype Nexus Dogu.
 Technical details on a release can be found in the corresponding Changelog.
 
 ## [Unreleased]
+### Changed 
+- Redis has been updated to version v6.2.20 [Release Notes](https://github.com/redis/redis/releases/tag/6.2.20)
+### Security
+- CVE Fixes:
+* [CVE-2025-49844](https://nvd.nist.gov/vuln/detail/CVE-2025-49844) – A Lua script may lead to remote code execution  
+* [CVE-2025-46817](https://nvd.nist.gov/vuln/detail/CVE-2025-46817) – A Lua script may lead to integer overflow and potential RCE  
+* [CVE-2025-46818](https://www.wiz.io/vulnerability-database/cve/cve-2025-46818) – A Lua script can be executed in the context of another user  
+* [CVE-2025-46819](https://nvd.nist.gov/vuln/detail/CVE-2025-46819) – Lua out-of-bound read  
 
 ## [v6.2.19-1] - 2025-07-08
+### Changed 
+- Redis has been updated to version v6.2.19 [Release Notes](https://github.com/redis/redis/releases/tag/6.2.19)
 
 ## [v6.2.17-3] - 2025-04-25
 ### Changed

--- a/dogu.json
+++ b/dogu.json
@@ -1,6 +1,6 @@
 {
   "Name": "official/redis",
-  "Version": "6.2.19-1",
+  "Version": "6.2.20-0",
   "DisplayName": "Redis",
   "Description": "Fast in-memory database",
   "Category": "Development Apps",


### PR DESCRIPTION
- [#31] CVE Fixes:
* [CVE-2025-49844](https://nvd.nist.gov/vuln/detail/CVE-2025-49844) - A Lua script may lead to remote code execution
* [CVE-2025-46817](https://nvd.nist.gov/vuln/detail/CVE-2025-46817) - A Lua script may lead to integer overflow and potential RCE
* [CVE-2025-46818](https://www.wiz.io/vulnerability-database/cve/cve-2025-46818) - A Lua script can be executed in the context of another user
* [CVE-2025-46819](https://nvd.nist.gov/vuln/detail/CVE-2025-46819) - LUA out-of-bound read