### PR TITLE
rotate default_admin_password but keep service account acls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- [#46] Rotate `default_admin_password` once on instances coming from redis <= 6.2.21-1, replacing a value that was generated insecurely
+  - The rotation happens in `startup.sh` before the redis server starts, guarded by the new config key `default_admin_password_rotated`
+  - Only the `default` user's line in `data/service-accounts.acl` is rewritten; service accounts of other dogus are kept
 
 ## [v6.2.23-1] - 2026-08-05
 ### Changed

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -1,10 +1,12 @@
 # Release Notes
 
-Im Folgenden finden Sie die Release Notes für das Sonatype Nexus-Dogu. 
+Im Folgenden finden Sie die Release Notes für das Redis-Dogu. 
 
 Technische Details zu einem Release finden Sie im zugehörigen Changelog.
 
 ## [Unreleased]
+### Security
+- Das Passwort des Redis-Administrationsbenutzers wird einmalig durch ein sicherer erzeugtes ersetzt. Die Zugänge der anderen Dogus zu Redis bleiben unverändert; ein Eingreifen ist nicht erforderlich.
 
 ## [v6.2.23-1] - 2026-08-05
 - Wir haben nur technische Änderungen vorgenommen. Näheres finden Sie in den Changelogs.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -1,10 +1,12 @@
 # Release Notes
 
-Below you will find the release notes for the Sonatype Nexus Dogu. 
+Below you will find the release notes for the Redis Dogu. 
 
 Technical details on a release can be found in the corresponding Changelog.
 
 ## [Unreleased]
+### Security
+- The password of the redis administration user is replaced once by a more securely generated one. The access of other dogus to redis stays unchanged; no action is required.
 
 ## [v6.2.23-1] - 2026-08-05
 - We have only made technical changes. You can find more details in the changelogs.

--- a/resources/create-sa.sh
+++ b/resources/create-sa.sh
@@ -3,8 +3,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SERVICE="$1"
-if [[ X"${SERVICE}" == X"" ]]; then
+SERVICE="${1:-}"
+if [[ -z "${SERVICE}" ]]; then
     echo "usage create-sa.sh servicename"
     exit 1
 fi

--- a/resources/remove-sa.sh
+++ b/resources/remove-sa.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 SERVICE="${1:-}"
-if [ X"${SERVICE}" = X"" ]; then
+if [[ -z "${SERVICE}" ]]; then
     echo "usage remove-sa.sh servicename"
     exit 1
 fi

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -23,6 +23,7 @@ REDIS_LOGLEVEL="$(getDoguLogLevel)"
 export REDIS_LOGLEVEL
 
 render_default_user_config
+rotate_default_user_password
 render_configuration
 
 doguctl state "ready"

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -26,15 +26,60 @@ function getDoguLogLevel() {
   echo "${log_level}"
 }
 
+# Length of the redis default user's password, as generated since the very first release.
+DEFAULT_ADMIN_PASSWORD_LENGTH=12
+
+# Prints a new password for the redis default user.
+function generate_default_admin_password() {
+  doguctl random -l "${DEFAULT_ADMIN_PASSWORD_LENGTH}"
+}
+
+# Prints the ACL file without the default user's line, all other lines unchanged:
+#   user default on #ab12 ~* &* +@all   -> dropped
+#   user sa-scm  on #99aa ~* &* +@all   -> kept
+function acl_without_default_user() {
+  awk '$1 == "user" && $2 == "default" { next } { print }' "${1}"
+}
+
 function render_default_user_config() {
   # only render service accounts file if it does not already exists
   if [[ -f "${CONF_DIR}/data/service-accounts.acl" ]]; then
     return
   fi
   local default_password
-  default_password=$(doguctl random -l 12)
+  default_password=$(generate_default_admin_password)
   doguctl config -e 'default_admin_password' "${default_password}"
   doguctl template "/service-accounts.acl.tpl" "${CONF_DIR}/data/service-accounts.acl"
+  # A freshly rendered password already comes from the fixed doguctl, so there is
+  # nothing left to migrate for this instance.
+  doguctl config 'default_admin_password_rotated' "true"
+}
+
+# Replaces a default_admin_password that was generated with an insecure doguctl random.
+# Here the redis server is guaranteed to be down and starts right after this function
+function rotate_default_user_password() {
+  local acl_file="${CONF_DIR}/data/service-accounts.acl"
+  local rotated new_password
+  rotated="$(doguctl config -d "false" 'default_admin_password_rotated')"
+  # if rotated or first time, no rotation
+  if [[ "${rotated}" == "true" ]] || [[ ! -f "${acl_file}" ]]; then
+    return
+  fi
+
+  echo "Rotating default_admin_password to replace a potentially insecure value..."
+  new_password="$(generate_default_admin_password)"
+
+  # Drop the default user, then append it with the new password. Every other line is a
+  # service account written by ACL SAVE and must survive
+  acl_without_default_user "${acl_file}" > "${acl_file}.tmp"
+  echo "user default +@all ~* on >${new_password}" >> "${acl_file}.tmp"
+  # Copy to ensure owner and mode of the original file are kept.
+  cat "${acl_file}.tmp" > "${acl_file}"
+  rm -f "${acl_file}.tmp"
+
+  # Save to dogu config and store rotated status
+  doguctl config -e 'default_admin_password' "${new_password}"
+  doguctl config 'default_admin_password_rotated' "true"
 }
 
 function render_configuration() {

--- a/unitTests/util.bats
+++ b/unitTests/util.bats
@@ -14,10 +14,15 @@ setup() {
   export doguctl
   ln -s "${doguctl}" "${BATS_TMPDIR}/doguctl"
   export PATH="${PATH}:${BATS_TMPDIR}"
+
+  # util.sh runs with 'set -o nounset' and reads CONF_DIR, so it must always be set
+  export CONF_DIR="${BATS_TMPDIR}/conf"
+  mkdir -p "${CONF_DIR}/data"
 }
 
 teardown() {
   rm "${BATS_TMPDIR}/doguctl"
+  rm -rf "${CONF_DIR}"
 }
 
 @test "setDoguLogLevel() should set log level to notice  if INFO was configured" {
@@ -89,5 +94,78 @@ teardown() {
 
   assert_success
   assert_line "warning"
+  assert_equal "$(mock_get_call_num "${doguctl}")" "1"
+}
+
+@test "rotate_default_user_password() should replace the freshly rendered default user line" {
+  source /workspace/resources/util.sh
+  local acl_file="${CONF_DIR}/data/service-accounts.acl"
+  echo "user default +@all ~* on >oldPlain" > "${acl_file}"
+  mock_set_status "${doguctl}" 0
+  mock_set_output "${doguctl}" "false" 1
+  mock_set_output "${doguctl}" "newSecret123" 2
+
+  run rotate_default_user_password
+
+  assert_success
+  assert_equal "$(cat "${acl_file}")" "user default +@all ~* on >newSecret123"
+}
+
+@test "rotate_default_user_password() should keep service accounts, replace the hashed default user and write the marker last" {
+  
+  # ARRANGE
+
+  source /workspace/resources/util.sh
+  local acl_file="${CONF_DIR}/data/service-accounts.acl"
+  # add two entries in acl file
+  cat > "${acl_file}" <<'EOF'
+user default on #ab12 ~* &* +@all
+user sa-scm on #99aa ~* &* +@all
+EOF
+  chmod 640 "${acl_file}"
+  mock_set_status "${doguctl}" 0
+  mock_set_output "${doguctl}" "false" 1
+  mock_set_output "${doguctl}" "newSecret123" 2
+
+  # ACT
+
+  run rotate_default_user_password
+
+  # ASSERT
+
+  assert_success
+  # the service account survives, the default user is replaced by the new password
+  run cat "${acl_file}"
+  assert_line "user sa-scm on #99aa ~* &* +@all"
+  assert_line "user default +@all ~* on >newSecret123"
+  refute_line "user default on #ab12 ~* &* +@all"
+  # exactly 2 entries, deafault and sa-scm not 2x default
+  assert_equal "${#lines[@]}" "2"
+  # no leftover temporary file, mode of the volume file is untouched
+  assert_file_not_exist "${acl_file}.tmp"
+  assert_equal "$(stat -c '%a' "${acl_file}")" "640"
+  # the marker is written after the password, so an aborted rotation is retried
+  # doguctl call sum
+  # #1 config - read rotated flag
+  # #2 random - generate password
+  # #3 config - write password
+  # #4 config - set rotated flag
+  assert_equal "$(mock_get_call_num "${doguctl}")" "4"
+  assert_equal "$(mock_get_call_args "${doguctl}" 3)" "config -e default_admin_password newSecret123"
+  assert_equal "$(mock_get_call_args "${doguctl}" 4)" "config default_admin_password_rotated true"
+}
+
+@test "rotate_default_user_password() should do nothing if the rotation marker is already true" {
+  source /workspace/resources/util.sh
+  local acl_file="${CONF_DIR}/data/service-accounts.acl"
+  echo "user default on #ab12 ~* &* +@all" > "${acl_file}"
+  mock_set_status "${doguctl}" 0
+  mock_set_output "${doguctl}" "true" 1
+
+  run rotate_default_user_password
+
+  assert_success
+  assert_equal "$(cat "${acl_file}")" "user default on #ab12 ~* &* +@all"
+  # only the marker was read, nothing was generated or written
   assert_equal "$(mock_get_call_num "${doguctl}")" "1"
 }

--- a/unitTests/util.bats
+++ b/unitTests/util.bats
@@ -169,3 +169,15 @@ EOF
   # only the marker was read, nothing was generated or written
   assert_equal "$(mock_get_call_num "${doguctl}")" "1"
 }
+
+@test "rotate_default_user_password() should do nothing if there is no acl file yet" {
+  source /workspace/resources/util.sh
+  mock_set_status "${doguctl}" 0
+  mock_set_output "${doguctl}" "false" 1
+
+  run rotate_default_user_password
+
+  assert_success
+  assert_file_not_exist "${CONF_DIR}/data/service-accounts.acl"
+  assert_equal "$(mock_get_call_num "${doguctl}")" "1"
+}


### PR DESCRIPTION
fix lint issues

edit docs

introduce rotate_default_user_password to change default user but keeping other ones